### PR TITLE
stop polling via publish / subscribe

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,12 +1,14 @@
 [IP150]
 Pincode: 1234                           ;Not needed anymore
-Password: abcd
-IP: 10.0.0.120
+Password: passw
+IP: 127.0.0.1
 IP_Software_Port: 10000
 
 [MQTT Broker]
-IP: 10.0.0.130
+IP: 127.0.0.1
 Port: 1883
+Username: usr
+Password: passw
 
 [Alarm]
 Alarm_Model = ParadoxMG5050             ;Currently not used
@@ -23,5 +25,7 @@ Topic_Publish_Labels = Paradox/Labels   ;The topic used to publish labels
 Topic_Publish_AppState = Paradox/State  ;Publishes the scripts internal states, useful to check if connection is alive
 
 [Application]
+Polling_Auto_Stop = True				;Allow another application to log this script out
+Polling_Restart_Delay = 30				;Seconds to wait before polling after another system forces polling to stop
 Debug_Mode = 1                          ;0=Minimal, 1=Basic, 2=Verbose
 Startup_Update_All_Labels = True        ;Upon startup collect all labels from the alarm (configured names of things). Required for config item: Topic_Publish_Labels. If you see the script stuck at trying to update the labels, then disable this option


### PR DESCRIPTION
So disclaimer:
My first time even looking at python! 

I added config sections for MQTT user/pass - i'm using rabbitMQ so need that. Also added 2 new settings to auto stop polling, as well as a delay.

Basically subscribing to the events as well, so when that message comes in, I place the "disable polling" message back on the q, only difference being that I flag it with "internal" as the payload. When the message comes back in, i look for the internal flag to do the rest of the processing. Not sure if this is more or less what you had in mind? Just thought that this would be the least intrusive change to your original implementation.

The result is that a login from another system will fail, but raises this trigger in the currently connected system. We can log out, but have to log in again from the other system. The result can be seen below. Seems to do what I expect.
![image](https://cloud.githubusercontent.com/assets/898952/25650057/93e7807a-2fda-11e7-8bfc-98c9648d37b3.png)

That being said, it's still not perfect:
1. It seems that at times there is a bit of a delay on the message, causing you to raise multiple events by trying to log in from another system
2. My IP150 is currently sitting in an endless loop, connects, does it's thing, waits for events, then randomly the log off comes through - not sure.

Just want to get your thoughts on this approach before I continue.

